### PR TITLE
fix: fix for deadlock

### DIFF
--- a/include/workspace/utility.hpp
+++ b/include/workspace/utility.hpp
@@ -189,8 +189,8 @@ private:
 };
 
 
-using task_t = std::function<void()>;
-// using task_t = function_<void()>;
+// using task_t = std::function<void()>;
+using task_t = function_<void()>;
 
 /**
  * @brief std::future collector


### PR DESCRIPTION
当主线程执行两次`wait_tasks`时，有概率发生死锁。主线程第一次`wait_tasks`，`return res`可能会先于worker线程执行`thread_cv.wait(locker, [this] { return !is_waiting; })`；然后主线程第二次`wait_tasks`将`is_waiting`改成`true`，如果第一轮的worker没有及时被调度，导致其一直阻塞在`thread_cv.wait(locker, [this] { return !is_waiting; })`处，无法进行第二轮的`task_done_workers`计数，于此同时，主线程也阻塞在`res = task_done_cv.wait_for(...)`处，最终形成死锁。

`test_workbranch.cc`和`test_workspace.cc`均存在上述问题。

目前的修改是让每次`wait_tasks`都需要等待所有的worker线程执行完`thread_cv.wait(locker, [this] { return !is_waiting; })`再`return res`。